### PR TITLE
feat: add initial security configuration

### DIFF
--- a/src/main/java/com/habittracker/api/security/config/SecurityConfig.java
+++ b/src/main/java/com/habittracker/api/security/config/SecurityConfig.java
@@ -1,0 +1,50 @@
+package com.habittracker.api.security.config;
+
+import com.habittracker.api.auth.service.UserDetailsServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final UserDetailsServiceImpl userDetailsService;
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.csrf(AbstractHttpConfigurer::disable)
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            auth -> auth.requestMatchers("/api/auth/**").permitAll().anyRequest().authenticated());
+
+    // TODO: Add JWT filter when ready
+    // .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+
+    return http.build();
+  }
+
+  @Bean
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig)
+      throws Exception {
+    return authConfig.getAuthenticationManager();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}


### PR DESCRIPTION
## Summary

Add initial security configuration which define SecurityFilterChain, AuthenticationManager and PasswordEncoder beans. 

## Changes

SecurityFilterChain config:
- Disable the CSRF protection for development
- Set session creation policy to stateless
- Allow access to authentication related endpoints (e.g. login and register)

## Issue

Closes #15
