### PR TITLE
test: migrate to Testcontainers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ spotless {
     }
 }
 
-
 repositories {
     mavenCentral()
 }
@@ -53,7 +52,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'com.h2database:h2:2.3.232'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/test/java/com/habittracker/api/HabitTrackerApiApplicationTests.java
+++ b/src/test/java/com/habittracker/api/HabitTrackerApiApplicationTests.java
@@ -1,12 +1,9 @@
 package com.habittracker.api;
 
+import com.habittracker.api.config.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@ActiveProfiles("test")
-class HabitTrackerApiApplicationTests {
+class HabitTrackerApiApplicationTests extends BaseIntegrationTest {
 
   @Test
   void contextLoads() {}

--- a/src/test/java/com/habittracker/api/config/BaseIntegrationTest.java
+++ b/src/test/java/com/habittracker/api/config/BaseIntegrationTest.java
@@ -1,0 +1,12 @@
+package com.habittracker.api.config;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(TestConfig.class)
+public abstract class BaseIntegrationTest {
+  // Common test utilities can be added here
+}

--- a/src/test/java/com/habittracker/api/config/TestConfig.java
+++ b/src/test/java/com/habittracker/api/config/TestConfig.java
@@ -1,0 +1,20 @@
+package com.habittracker.api.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestConfig {
+
+  private static final String POSTGRES_IMAGE = "postgres:15-alpine";
+
+  @Bean
+  @ServiceConnection
+  public PostgreSQLContainer<?> postgresContainer() {
+    return new PostgreSQLContainer<>(DockerImageName.parse(POSTGRES_IMAGE))
+        .withReuse(true);
+  }
+}

--- a/src/test/java/com/habittracker/api/config/TestConfig.java
+++ b/src/test/java/com/habittracker/api/config/TestConfig.java
@@ -14,7 +14,6 @@ public class TestConfig {
   @Bean
   @ServiceConnection
   public PostgreSQLContainer<?> postgresContainer() {
-    return new PostgreSQLContainer<>(DockerImageName.parse(POSTGRES_IMAGE))
-        .withReuse(true);
+    return new PostgreSQLContainer<>(DockerImageName.parse(POSTGRES_IMAGE)).withReuse(true);
   }
 }

--- a/src/test/java/com/habittracker/api/security/jwt/config/JwtPropertiesIT.java
+++ b/src/test/java/com/habittracker/api/security/jwt/config/JwtPropertiesIT.java
@@ -2,16 +2,13 @@ package com.habittracker.api.security.jwt.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.habittracker.api.config.BaseIntegrationTest;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@ActiveProfiles("test")
-public class JwtPropertiesIT {
+public class JwtPropertiesIT extends BaseIntegrationTest {
 
   @Autowired private JwtProperties jwtProperties;
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,19 +1,11 @@
 spring:
- datasource:
-  url: jdbc:h2:mem:mydb
-  username: sa
-  password: password
-  driverClassName: org.h2.Driver
  jpa:
-  database-platform: org.hibernate.dialect.H2Dialect
+  hibernate:
+   ddl-auto: create-drop
+
 jwt:
  secret: 9NuCXLE3rpz8/lPYeIag9xs7wyRHKat8exvUmlm01S8=
  issuer: test-issuer
  expiration-duration: PT1M
  not-before-leeway-duration: PT20M
  clock-skew-seconds: 50
-
-
-
-
-


### PR DESCRIPTION
## Summary

This PR migrates our integration tests from H2 in-memory database to Testcontainers, providing a more accurate test environment with real PostgreSQL instances running in Docker containers.

## Changes

- Removed H2 database dependency and added Testcontainers dependencies (spring-boot-testcontainers, junit-jupiter, postgresql)
- Created `BaseIntegrationTest` abstract class that all integration tests should extend
- Added `TestConfig` to configure PostgreSQL container with auto-connection through Spring Boot
- Updated existing test classes to extend `BaseIntegrationTest`
- Simplified `application-test.yml` to work with Testcontainers PostgreSQL
- Enabled container reuse to improve test execution time

## Issue

Closes #28

## Checklist

- [x] Tests updated
- [x] Code builds successfully
- [x] Code review requested

## Notes for Reviewers

- Test execution might be slightly slower on first run due to container startup time, but subsequent runs should be faster with container reuse enabled
- This change should help catch any database-specific issues earlier in development
- All existing tests have been verified to work with the new configuration