### PR TITLE
fix: default value of jwt clock skew seconds

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ jwt:
  issuer: ${JWT_ISSUER:jwt-issuer}
  expiration-duration: ${JWT_EXPIRATION_DURATION:PT10M}
  not-before-leeway-duration: ${JWT_NOT_BEFORE_LEEWAY_DURATION:PT15S}
- clock-skew-seconds: ${JWT_CLOCK_SKEW_SECONDS:PT25S}
+ clock-skew-seconds: ${JWT_CLOCK_SKEW_SECONDS:25}
 
 
 


### PR DESCRIPTION
It needs to be changed because in `JwtProperties` it is set up to Integer:
`private Integer clockSkewSeconds;`