### PR TITLE
feat: refresh token endpoint

### DIFF
--- a/src/main/java/com/habittracker/api/auth/controller/AuthController.java
+++ b/src/main/java/com/habittracker/api/auth/controller/AuthController.java
@@ -2,6 +2,8 @@ package com.habittracker.api.auth.controller;
 
 import com.habittracker.api.auth.dto.AuthRequest;
 import com.habittracker.api.auth.dto.AuthResponse;
+import com.habittracker.api.auth.dto.RefreshTokenRequest;
+import com.habittracker.api.auth.dto.RefreshTokenResponse;
 import com.habittracker.api.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +34,14 @@ public class AuthController {
   public ResponseEntity<AuthResponse> login(@Valid @RequestBody AuthRequest request) {
     AuthResponse response = userService.login(request);
     log.info("User with email - {}, logged in successfully", request.email());
+    return ResponseEntity.ok(response);
+  }
+
+  @PostMapping("/refresh")
+  public ResponseEntity<RefreshTokenResponse> refresh(
+      @Valid @RequestBody RefreshTokenRequest request) {
+    RefreshTokenResponse response = userService.refreshToken(request);
+    log.info("Refresh token used successfully");
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/habittracker/api/auth/dto/AuthResponse.java
+++ b/src/main/java/com/habittracker/api/auth/dto/AuthResponse.java
@@ -1,3 +1,3 @@
 package com.habittracker.api.auth.dto;
 
-public record AuthResponse(String email, String token, String message) {}
+public record AuthResponse(String email, String token, String refreshToken, String message) {}

--- a/src/main/java/com/habittracker/api/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/habittracker/api/auth/dto/RefreshTokenRequest.java
@@ -1,0 +1,5 @@
+package com.habittracker.api.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenRequest(@NotBlank String refreshToken) {}

--- a/src/main/java/com/habittracker/api/auth/dto/RefreshTokenResponse.java
+++ b/src/main/java/com/habittracker/api/auth/dto/RefreshTokenResponse.java
@@ -1,0 +1,3 @@
+package com.habittracker.api.auth.dto;
+
+public record RefreshTokenResponse(String accessToken, String refreshToken, String message) {}

--- a/src/main/java/com/habittracker/api/auth/model/RefreshTokenEntity.java
+++ b/src/main/java/com/habittracker/api/auth/model/RefreshTokenEntity.java
@@ -1,0 +1,23 @@
+package com.habittracker.api.auth.model;
+
+import com.habittracker.api.core.entity.BaseEntity;
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@Setter
+public class RefreshTokenEntity extends BaseEntity {
+
+  @Column(nullable = false, unique = true)
+  private String token;
+
+  @Column(nullable = false)
+  private String email;
+
+  @Column(nullable = false)
+  private Instant expiresAt;
+}

--- a/src/main/java/com/habittracker/api/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/habittracker/api/auth/repository/RefreshTokenRepository.java
@@ -9,4 +9,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity
   Optional<RefreshTokenEntity> findByToken(String token);
 
   void deleteByToken(String token);
+
+  void deleteAllByEmail(String email);
 }

--- a/src/main/java/com/habittracker/api/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/habittracker/api/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.habittracker.api.auth.repository;
+
+import com.habittracker.api.auth.model.RefreshTokenEntity;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, UUID> {
+  Optional<RefreshTokenEntity> findByToken(String token);
+
+  void deleteByToken(String token);
+}

--- a/src/main/java/com/habittracker/api/auth/service/AuthService.java
+++ b/src/main/java/com/habittracker/api/auth/service/AuthService.java
@@ -2,9 +2,13 @@ package com.habittracker.api.auth.service;
 
 import com.habittracker.api.auth.dto.AuthRequest;
 import com.habittracker.api.auth.dto.AuthResponse;
+import com.habittracker.api.auth.dto.RefreshTokenRequest;
+import com.habittracker.api.auth.dto.RefreshTokenResponse;
 
 public interface AuthService {
   AuthResponse register(AuthRequest request);
 
   AuthResponse login(AuthRequest request);
+
+  RefreshTokenResponse refreshToken(RefreshTokenRequest request);
 }

--- a/src/main/java/com/habittracker/api/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/habittracker/api/auth/service/RefreshTokenService.java
@@ -8,4 +8,6 @@ public interface RefreshTokenService {
   String getEmailFromRefreshToken(String refreshToken);
 
   void revokeRefreshToken(String refreshToken);
+
+  void revokeAllRefreshTokensForUser(String email);
 }

--- a/src/main/java/com/habittracker/api/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/habittracker/api/auth/service/RefreshTokenService.java
@@ -1,0 +1,11 @@
+package com.habittracker.api.auth.service;
+
+public interface RefreshTokenService {
+  String createRefreshToken(String email);
+
+  boolean isValid(String refreshToken);
+
+  String getEmailFromRefreshToken(String refreshToken);
+
+  void revokeRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/habittracker/api/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/habittracker/api/auth/service/impl/AuthServiceImpl.java
@@ -15,9 +15,8 @@ import com.habittracker.api.auth.repository.UserRepository;
 import com.habittracker.api.auth.service.AuthService;
 import com.habittracker.api.auth.service.RefreshTokenService;
 import com.habittracker.api.security.jwt.service.JwtService;
-import java.util.Collections;
-
 import jakarta.transaction.Transactional;
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;

--- a/src/main/java/com/habittracker/api/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/habittracker/api/auth/service/impl/AuthServiceImpl.java
@@ -58,6 +58,7 @@ public class AuthServiceImpl implements AuthService {
     log.info("Registering new user: {}", request.email());
     UserEntity savedUser = userRepository.save(user);
 
+    refreshTokenService.revokeAllRefreshTokensForUser(savedUser.getEmail());
     String token = jwtService.generateToken(savedUser.getEmail());
     String refreshToken = refreshTokenService.createRefreshToken(savedUser.getEmail());
     return new AuthResponse(savedUser.getEmail(), token, refreshToken, REGISTER_SUCCESS_MESSAGE);
@@ -72,6 +73,7 @@ public class AuthServiceImpl implements AuthService {
 
       if (auth.isAuthenticated()) {
         log.info("User authenticated: {}", request.email());
+        refreshTokenService.revokeAllRefreshTokensForUser(request.email());
         String token = jwtService.generateToken(request.email());
         String refreshToken = refreshTokenService.createRefreshToken(request.email());
         return new AuthResponse(request.email(), token, refreshToken, LOGIN_SUCCESS_MESSAGE);

--- a/src/main/java/com/habittracker/api/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/habittracker/api/auth/service/impl/AuthServiceImpl.java
@@ -4,6 +4,8 @@ import static com.habittracker.api.auth.utils.AuthConstants.*;
 
 import com.habittracker.api.auth.dto.AuthRequest;
 import com.habittracker.api.auth.dto.AuthResponse;
+import com.habittracker.api.auth.dto.RefreshTokenRequest;
+import com.habittracker.api.auth.dto.RefreshTokenResponse;
 import com.habittracker.api.auth.exception.EmailAlreadyExistsException;
 import com.habittracker.api.auth.model.RoleEntity;
 import com.habittracker.api.auth.model.RoleType;
@@ -11,6 +13,7 @@ import com.habittracker.api.auth.model.UserEntity;
 import com.habittracker.api.auth.repository.RoleRepository;
 import com.habittracker.api.auth.repository.UserRepository;
 import com.habittracker.api.auth.service.AuthService;
+import com.habittracker.api.auth.service.RefreshTokenService;
 import com.habittracker.api.security.jwt.service.JwtService;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +36,7 @@ public class AuthServiceImpl implements AuthService {
   private final AuthenticationManager authManager;
   private final JwtService jwtService;
   private final PasswordEncoder passwordEncoder;
+  private final RefreshTokenService refreshTokenService;
 
   @Override
   public AuthResponse register(AuthRequest request) {
@@ -55,8 +59,8 @@ public class AuthServiceImpl implements AuthService {
     UserEntity savedUser = userRepository.save(user);
 
     String token = jwtService.generateToken(savedUser.getEmail());
-
-    return new AuthResponse(savedUser.getEmail(), token, REGISTER_SUCCESS_MESSAGE);
+    String refreshToken = refreshTokenService.createRefreshToken(savedUser.getEmail());
+    return new AuthResponse(savedUser.getEmail(), token, refreshToken, REGISTER_SUCCESS_MESSAGE);
   }
 
   @Override
@@ -69,8 +73,8 @@ public class AuthServiceImpl implements AuthService {
       if (auth.isAuthenticated()) {
         log.info("User authenticated: {}", request.email());
         String token = jwtService.generateToken(request.email());
-
-        return new AuthResponse(request.email(), token, LOGIN_SUCCESS_MESSAGE);
+        String refreshToken = refreshTokenService.createRefreshToken(request.email());
+        return new AuthResponse(request.email(), token, refreshToken, LOGIN_SUCCESS_MESSAGE);
       }
 
       log.error("Authentication failed for user with email: {}", request.email());
@@ -79,5 +83,20 @@ public class AuthServiceImpl implements AuthService {
       log.error("Authentication error: {}", e.getMessage());
       throw new BadCredentialsException(INVALID_CREDENTIALS_ERROR);
     }
+  }
+
+  @Override
+  public RefreshTokenResponse refreshToken(RefreshTokenRequest request) {
+    String refreshToken = request.refreshToken();
+    if (!refreshTokenService.isValid(refreshToken)) {
+      throw new BadCredentialsException(INVALID_REFRESH_TOKEN_MESSAGE);
+    }
+
+    String email = refreshTokenService.getEmailFromRefreshToken(refreshToken);
+    String newAccessToken = jwtService.generateToken(email);
+
+    refreshTokenService.revokeRefreshToken(refreshToken);
+    String newRefreshToken = refreshTokenService.createRefreshToken(email);
+    return new RefreshTokenResponse(newAccessToken, newRefreshToken, REFRESH_SUCCESS_MESSAGE);
   }
 }

--- a/src/main/java/com/habittracker/api/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/habittracker/api/auth/service/impl/AuthServiceImpl.java
@@ -16,6 +16,8 @@ import com.habittracker.api.auth.service.AuthService;
 import com.habittracker.api.auth.service.RefreshTokenService;
 import com.habittracker.api.security.jwt.service.JwtService;
 import java.util.Collections;
+
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -29,6 +31,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional
 public class AuthServiceImpl implements AuthService {
 
   private final UserRepository userRepository;

--- a/src/main/java/com/habittracker/api/auth/service/impl/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/habittracker/api/auth/service/impl/RefreshTokenServiceImpl.java
@@ -1,15 +1,14 @@
 package com.habittracker.api.auth.service.impl;
 
-import static com.habittracker.api.auth.utils.AuthConstants.*;
-
 import com.habittracker.api.auth.model.RefreshTokenEntity;
 import com.habittracker.api.auth.repository.RefreshTokenRepository;
 import com.habittracker.api.auth.service.RefreshTokenService;
+import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,13 +17,16 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
 
   private final RefreshTokenRepository refreshTokenRepository;
 
+  @Value("${refresh-token.expiration-duration}")
+  private Duration refreshTokenExpiration;
+
   @Override
   public String createRefreshToken(String email) {
     String token = UUID.randomUUID().toString();
     RefreshTokenEntity entity = new RefreshTokenEntity();
     entity.setToken(token);
     entity.setEmail(email);
-    entity.setExpiresAt(Instant.now().plus(REFRESH_TOKEN_EXPIRY_DAYS, ChronoUnit.DAYS));
+    entity.setExpiresAt(Instant.now().plus(refreshTokenExpiration));
     refreshTokenRepository.save(entity);
     return token;
   }

--- a/src/main/java/com/habittracker/api/auth/service/impl/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/habittracker/api/auth/service/impl/RefreshTokenServiceImpl.java
@@ -1,0 +1,50 @@
+package com.habittracker.api.auth.service.impl;
+
+import static com.habittracker.api.auth.utils.AuthConstants.*;
+
+import com.habittracker.api.auth.model.RefreshTokenEntity;
+import com.habittracker.api.auth.repository.RefreshTokenRepository;
+import com.habittracker.api.auth.service.RefreshTokenService;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenServiceImpl implements RefreshTokenService {
+
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  @Override
+  public String createRefreshToken(String email) {
+    String token = UUID.randomUUID().toString();
+    RefreshTokenEntity entity = new RefreshTokenEntity();
+    entity.setToken(token);
+    entity.setEmail(email);
+    entity.setExpiresAt(Instant.now().plus(REFRESH_TOKEN_EXPIRY_DAYS, ChronoUnit.DAYS));
+    refreshTokenRepository.save(entity);
+    return token;
+  }
+
+  @Override
+  public boolean isValid(String refreshToken) {
+    Optional<RefreshTokenEntity> entityOpt = refreshTokenRepository.findByToken(refreshToken);
+    return entityOpt.isPresent() && entityOpt.get().getExpiresAt().isAfter(Instant.now());
+  }
+
+  @Override
+  public String getEmailFromRefreshToken(String refreshToken) {
+    return refreshTokenRepository
+        .findByToken(refreshToken)
+        .map(RefreshTokenEntity::getEmail)
+        .orElse(null);
+  }
+
+  @Override
+  public void revokeRefreshToken(String refreshToken) {
+    refreshTokenRepository.deleteByToken(refreshToken);
+  }
+}

--- a/src/main/java/com/habittracker/api/auth/service/impl/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/habittracker/api/auth/service/impl/RefreshTokenServiceImpl.java
@@ -47,4 +47,9 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
   public void revokeRefreshToken(String refreshToken) {
     refreshTokenRepository.deleteByToken(refreshToken);
   }
+
+  @Override
+  public void revokeAllRefreshTokensForUser(String email) {
+    refreshTokenRepository.deleteAllByEmail(email);
+  }
 }

--- a/src/main/java/com/habittracker/api/auth/utils/AuthConstants.java
+++ b/src/main/java/com/habittracker/api/auth/utils/AuthConstants.java
@@ -27,9 +27,6 @@ public final class AuthConstants {
   public static final String PASSWORD_REQUIRED_MESSAGE = "Password is required";
   public static final String PASSWORD_LENGTH_MESSAGE = "Password must be at least 6 characters";
 
-  // Refresh tokens
-  public static final long REFRESH_TOKEN_EXPIRY_DAYS = 7;
-
   private AuthConstants() {
     throw new UnsupportedOperationException("Utility class, do not instantiate");
   }

--- a/src/main/java/com/habittracker/api/auth/utils/AuthConstants.java
+++ b/src/main/java/com/habittracker/api/auth/utils/AuthConstants.java
@@ -5,10 +5,12 @@ public final class AuthConstants {
   // API endpoints
   public static final String REGISTER_ENDPOINT = "/api/auth/register";
   public static final String LOGIN_ENDPOINT = "/api/auth/login";
+  public static final String REFRESH_ENDPOINT = "/api/auth/refresh";
 
   // Response messages
   public static final String REGISTER_SUCCESS_MESSAGE = "Register successful";
   public static final String LOGIN_SUCCESS_MESSAGE = "Login successful";
+  public static final String REFRESH_SUCCESS_MESSAGE = "Token refreshed successfully";
 
   // Exception and error messages
   public static final String EMAIL_EXISTS_MESSAGE = "Email already exists";
@@ -17,12 +19,16 @@ public final class AuthConstants {
   public static final String VALIDATION_FAILED_MESSAGE =
       "Validation failed for one or more fields in your request.";
   public static final String MALFORMED_JSON_MESSAGE = "Request body is missing or malformed.";
+  public static final String INVALID_REFRESH_TOKEN_MESSAGE = "Invalid refresh token";
 
   // Validation messages
   public static final String EMAIL_REQUIRED_MESSAGE = "Email is required";
   public static final String INVALID_EMAIL_MESSAGE = "Email must be valid";
   public static final String PASSWORD_REQUIRED_MESSAGE = "Password is required";
   public static final String PASSWORD_LENGTH_MESSAGE = "Password must be at least 6 characters";
+
+  // Refresh tokens
+  public static final long REFRESH_TOKEN_EXPIRY_DAYS = 7;
 
   private AuthConstants() {
     throw new UnsupportedOperationException("Utility class, do not instantiate");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,3 +15,5 @@ jwt:
  expiration-duration: ${JWT_EXPIRATION_DURATION:PT10M}
  not-before-leeway-duration: ${JWT_NOT_BEFORE_LEEWAY_DURATION:PT15S}
  clock-skew-seconds: ${JWT_CLOCK_SKEW_SECONDS:25}
+refresh-token:
+ expiration-duration: ${REFRESH_TOKEN_EXPIRATION_DURATION:P7D}

--- a/src/test/java/com/habittracker/api/auth/controller/AuthControllerIT.java
+++ b/src/test/java/com/habittracker/api/auth/controller/AuthControllerIT.java
@@ -5,7 +5,9 @@ import static com.habittracker.api.config.constants.AuthTestConstants.*;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.habittracker.api.auth.dto.AuthRequest;
+import com.habittracker.api.auth.dto.RefreshTokenRequest;
 import com.habittracker.api.config.annotation.BaseIntegrationTest;
 import com.habittracker.api.testutils.AuthTestUtils;
 import com.habittracker.api.testutils.MockMvcTestUtils;
@@ -41,6 +43,7 @@ public class AuthControllerIT {
           .andExpect(status().isCreated())
           .andExpect(jsonPath("$.email", is(NEW_USER_EMAIL)))
           .andExpect(jsonPath("$.token", notNullValue()))
+          .andExpect(jsonPath("$.refreshToken", notNullValue()))
           .andExpect(jsonPath("$.message", is(REGISTER_SUCCESS_MESSAGE)));
     }
 
@@ -103,6 +106,7 @@ public class AuthControllerIT {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.email", is(TEST_EMAIL)))
           .andExpect(jsonPath("$.token", notNullValue()))
+          .andExpect(jsonPath("$.refreshToken", notNullValue()))
           .andExpect(jsonPath("$.message", is(LOGIN_SUCCESS_MESSAGE)));
     }
 
@@ -140,6 +144,29 @@ public class AuthControllerIT {
               jsonPath(
                   "$.errors.password",
                   anyOf(is(PASSWORD_REQUIRED_MESSAGE), is(PASSWORD_LENGTH_MESSAGE))));
+    }
+  }
+
+  @Nested
+  class RefreshTokenTests {
+    @Test
+    public void givenValidRefreshToken_whenRefresh_thenSuccess() throws Exception {
+      AuthRequest loginRequest = new AuthRequest(TEST_EMAIL, TEST_PASSWORD);
+      String loginResponse =
+          mockMvcTestUtils
+              .performPostRequest(LOGIN_ENDPOINT, loginRequest)
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+      String refreshToken = new ObjectMapper().readTree(loginResponse).get("refreshToken").asText();
+
+      RefreshTokenRequest refreshRequest = new RefreshTokenRequest(refreshToken);
+      mockMvcTestUtils
+          .performPostRequest(REFRESH_ENDPOINT, refreshRequest)
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.accessToken", notNullValue()))
+          .andExpect(jsonPath("$.refreshToken", notNullValue()))
+          .andExpect(jsonPath("$.message", is(REFRESH_SUCCESS_MESSAGE)));
     }
   }
 }

--- a/src/test/java/com/habittracker/api/auth/controller/AuthControllerIT.java
+++ b/src/test/java/com/habittracker/api/auth/controller/AuthControllerIT.java
@@ -181,13 +181,15 @@ public class AuthControllerIT {
       String refreshToken = new ObjectMapper().readTree(loginResponse).get("refreshToken").asText();
 
       RefreshTokenRequest refreshRequest = new RefreshTokenRequest(refreshToken);
-      String refreshResponse = mockMvcTestUtils
-          .performPostRequest(REFRESH_ENDPOINT, refreshRequest)
-          .andExpect(status().isOk())
-          .andReturn()
-          .getResponse()
-          .getContentAsString();
-      String newRefreshToken = new ObjectMapper().readTree(refreshResponse).get("refreshToken").asText();
+      String refreshResponse =
+          mockMvcTestUtils
+              .performPostRequest(REFRESH_ENDPOINT, refreshRequest)
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+      String newRefreshToken =
+          new ObjectMapper().readTree(refreshResponse).get("refreshToken").asText();
 
       mockMvcTestUtils
           .performPostRequest(REFRESH_ENDPOINT, refreshRequest)

--- a/src/test/java/com/habittracker/api/auth/service/impl/AuthServiceImplTest.java
+++ b/src/test/java/com/habittracker/api/auth/service/impl/AuthServiceImplTest.java
@@ -15,6 +15,7 @@ import com.habittracker.api.auth.model.RoleType;
 import com.habittracker.api.auth.model.UserEntity;
 import com.habittracker.api.auth.repository.RoleRepository;
 import com.habittracker.api.auth.repository.UserRepository;
+import com.habittracker.api.auth.service.RefreshTokenService;
 import com.habittracker.api.security.jwt.service.JwtService;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +40,7 @@ class AuthServiceImplTest {
   @Mock private AuthenticationManager authManager;
   @Mock private JwtService jwtService;
   @Mock private PasswordEncoder passwordEncoder;
+  @Mock private RefreshTokenService refreshTokenService;
   @InjectMocks private AuthServiceImpl authService;
 
   private AuthRequest validRequest;
@@ -58,6 +60,7 @@ class AuthServiceImplTest {
 
       assertThat(response.email()).isEqualTo(TEST_EMAIL);
       assertThat(response.token()).isEqualTo(JWT_TOKEN);
+      assertThat(response.refreshToken()).isEqualTo(REFRESH_TOKEN);
       assertThat(response.message()).isEqualTo(REGISTER_SUCCESS_MESSAGE);
       verify(userRepository).save(any(UserEntity.class));
     }
@@ -102,6 +105,7 @@ class AuthServiceImplTest {
 
       assertThat(response.email()).isEqualTo(TEST_EMAIL);
       assertThat(response.token()).isEqualTo(JWT_TOKEN);
+      assertThat(response.refreshToken()).isEqualTo(REFRESH_TOKEN);
       assertThat(response.message()).isEqualTo(LOGIN_SUCCESS_MESSAGE);
     }
 
@@ -147,6 +151,7 @@ class AuthServiceImplTest {
     UserEntity savedUser = createUser(TEST_EMAIL, ENCODED_PASSWORD, role);
     when(userRepository.save(any(UserEntity.class))).thenReturn(savedUser);
     when(jwtService.generateToken(TEST_EMAIL)).thenReturn(JWT_TOKEN);
+    when(refreshTokenService.createRefreshToken(TEST_EMAIL)).thenReturn(REFRESH_TOKEN);
   }
 
   private void setupForSuccessfulAuthentication() {
@@ -154,5 +159,6 @@ class AuthServiceImplTest {
     when(authManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).thenReturn(auth);
     when(auth.isAuthenticated()).thenReturn(true);
     when(jwtService.generateToken(TEST_EMAIL)).thenReturn(JWT_TOKEN);
+    when(refreshTokenService.createRefreshToken(TEST_EMAIL)).thenReturn(REFRESH_TOKEN);
   }
 }

--- a/src/test/java/com/habittracker/api/config/constants/AuthTestConstants.java
+++ b/src/test/java/com/habittracker/api/config/constants/AuthTestConstants.java
@@ -11,6 +11,9 @@ public final class AuthTestConstants {
   public static final String NONEXISTENT_EMAIL = "nonexistent@example.com";
   public static final String WRONG_PASSWORD = "wrongpassword";
   public static final String JWT_TOKEN = "jwt-token";
+  public static final String REFRESH_TOKEN = "dummy-refresh-token";
+  public static final String NEW_ACCESS_TOKEN = "new-access-token";
+  public static final String NEW_REFRESH_TOKEN = "new-refresh-token";
 
   // JSON Strings
   public static final String EMPTY_JSON = "{}";


### PR DESCRIPTION
## Summary

This PR implements a secure refresh token endpoint, allowing clients to obtain a new JWT access token using a valid refresh token. This enhances the authentication flow by supporting token renewal without requiring users to re-authenticate, improving both security and user experience.

## Changes

- Added a new endpoint in `AuthController` for refreshing access tokens.
- Implemented `RefreshTokenService` and its corresponding implementation to handle refresh token logic.
- Created DTOs: `RefreshTokenRequest` and `RefreshTokenResponse` for request/response payloads.
- Updated authentication logic in `AuthServiceImpl` to support refresh token issuance and validation.
- Added `RefreshTokenEntity` and `RefreshTokenRepository` for optional refresh token persistence in the database.
- Added/updated tests for the refresh token flow (`AuthControllerTest`, `AuthControllerIT`, etc.).
- Updated security configuration to allow access to the refresh endpoint.

## Issue

Closes #18

## Checklist

- [x] Tests added/updated
- [x] Code builds successfully
- [x] Code review requested