### PR TITLE
refactor: task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task---.md
+++ b/.github/ISSUE_TEMPLATE/task---.md
@@ -1,25 +1,11 @@
----
-name: "Task ✍️"
-about: Internal development task (feature, bugfix, test, etc.)
-labels: task
----
-
 ## Task Description
-Briefly describe what needs to be done.
+Brief description of what needs to be implemented.
 
-### Type
-- [ ] Feature
-- [ ] Bugfix
-- [ ] Refactor
-- [ ] Test
-- [ ] Documentation
-- [ ] CI/CD
+## Acceptance Criteria
+- [ ] Main functionality works as expected
+- [ ] Proper error handling implemented
+- [ ] Tests added
+- [ ] Documentation updated (if needed)
 
-### Checklist
-- [ ] Code implemented
-- [ ] Tests (if needed)
-- [ ] Committed and pushed
-- [ ] PR opened and reviewed
-
-### Additional Notes
-Add any extra info, links, or related issues.
+## Technical Notes
+Any specific technical considerations or constraints.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,13 +8,19 @@ Brief explanation of what this PR does and why.
 ## Issue
 Closes #<issue_number>  
 or  
-Related to #<issue_number> (if it doesn't fully close it)
+Related to #<issue_number>
+
+## Testing
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated
+- [ ] Manual testing completed
+- [ ] All tests pass
 
 ## Checklist
-- [ ] Tests added/updated
-- [ ] Documentation updated
 - [ ] Code builds successfully
+- [ ] Documentation updated (if needed)
+- [ ] No breaking changes (or documented)
 - [ ] Code review requested
 
 ## Notes for Reviewers
-Any extra context for the reviewer (e.g. why a decision was made, edge cases to test, etc.)
+Any extra context for the reviewer (testing approach, design decisions, areas of focus, etc.)


### PR DESCRIPTION
I do that mainly because the template for issues (internal development tasks) is way too verbose and detailed. Also do some minor adjustments to the PR template before we start working on the next development phases with domain business logic.