### PR TITLE
fix: add header for task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task---.md
+++ b/.github/ISSUE_TEMPLATE/task---.md
@@ -1,3 +1,10 @@
+---
+name: "Task ✍️"
+about: Internal development task (feature, bugfix, test, etc.)
+labels: task
+
+---
+
 ## Task Description
 Brief description of what needs to be implemented.
 


### PR DESCRIPTION
By mistake I removed the template header in last PR.