### PR TITLE
feat: delete check in endpoint

### DIFF
--- a/src/main/java/com/habittracker/api/checkin/constants/CheckInConstants.java
+++ b/src/main/java/com/habittracker/api/checkin/constants/CheckInConstants.java
@@ -4,4 +4,5 @@ public class CheckInConstants {
 
   public static final String DUPLICATION_CHECK_IN_MESSAGE =
       "A check-in for habit with id %s already exists for today.";
+  public static final String CHECK_IN_NOT_FOUND_MESSAGE = "Check-in not found.";
 }

--- a/src/main/java/com/habittracker/api/checkin/controller/CheckInController.java
+++ b/src/main/java/com/habittracker/api/checkin/controller/CheckInController.java
@@ -54,8 +54,7 @@ public class CheckInController {
 
   @DeleteMapping("/api/check-ins/{checkInId}")
   public ResponseEntity<Void> deleteCheckIn(
-      @NotNull @PathVariable UUID checkInId,
-      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+      @NotNull @PathVariable UUID checkInId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
     checkInService.deleteCheckIn(checkInId, userDetails.getUser());
     return ResponseEntity.noContent().build();
   }

--- a/src/main/java/com/habittracker/api/checkin/controller/CheckInController.java
+++ b/src/main/java/com/habittracker/api/checkin/controller/CheckInController.java
@@ -51,4 +51,12 @@ public class CheckInController {
     return ResponseEntity.ok(
         checkInService.getAllCheckIns(userDetails.getUser(), from, to, pageable));
   }
+
+  @DeleteMapping("/api/check-ins/{checkInId}")
+  public ResponseEntity<Void> deleteCheckIn(
+      @NotNull @PathVariable UUID checkInId,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    checkInService.deleteCheckIn(checkInId, userDetails.getUser());
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/com/habittracker/api/checkin/exception/CheckInNotFoundException.java
+++ b/src/main/java/com/habittracker/api/checkin/exception/CheckInNotFoundException.java
@@ -1,0 +1,11 @@
+package com.habittracker.api.checkin.exception;
+
+import static com.habittracker.api.checkin.constants.CheckInConstants.CHECK_IN_NOT_FOUND_MESSAGE;
+
+import com.habittracker.api.core.exception.ResourceNotFoundException;
+
+public class CheckInNotFoundException extends ResourceNotFoundException {
+  public CheckInNotFoundException() {
+    super(CHECK_IN_NOT_FOUND_MESSAGE);
+  }
+}

--- a/src/main/java/com/habittracker/api/checkin/exception/handler/CheckInExceptionHandler.java
+++ b/src/main/java/com/habittracker/api/checkin/exception/handler/CheckInExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.habittracker.api.checkin.exception.handler;
 
+import com.habittracker.api.checkin.exception.CheckInNotFoundException;
 import com.habittracker.api.checkin.exception.DuplicateCheckinException;
 import com.habittracker.api.core.exception.ApiError;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,6 +16,13 @@ public class CheckInExceptionHandler {
   public ResponseEntity<ApiError> handleDuplicateCheckInException(
       DuplicateCheckinException ex, HttpServletRequest request) {
     HttpStatus status = HttpStatus.CONFLICT;
+    return ResponseEntity.status(status).body(ApiError.from(ex.getMessage(), status, request));
+  }
+
+  @ExceptionHandler(CheckInNotFoundException.class)
+  public ResponseEntity<ApiError> handleCheckInNotFoundException(
+      CheckInNotFoundException ex, HttpServletRequest request) {
+    HttpStatus status = HttpStatus.NOT_FOUND;
     return ResponseEntity.status(status).body(ApiError.from(ex.getMessage(), status, request));
   }
 }

--- a/src/main/java/com/habittracker/api/checkin/helpers/CheckInHelper.java
+++ b/src/main/java/com/habittracker/api/checkin/helpers/CheckInHelper.java
@@ -1,0 +1,17 @@
+package com.habittracker.api.checkin.helpers;
+
+import com.habittracker.api.checkin.repository.CheckInRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CheckInHelper {
+
+  private final CheckInRepository checkInRepository;
+
+  public boolean isOwnedByUser(UUID checkInId, UUID userId) {
+    return checkInRepository.existsByIdAndHabitUserId(checkInId, userId);
+  }
+}

--- a/src/main/java/com/habittracker/api/checkin/repository/CheckInRepository.java
+++ b/src/main/java/com/habittracker/api/checkin/repository/CheckInRepository.java
@@ -6,4 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface CheckInRepository
-    extends JpaRepository<CheckInEntity, UUID>, JpaSpecificationExecutor<CheckInEntity> {}
+    extends JpaRepository<CheckInEntity, UUID>, JpaSpecificationExecutor<CheckInEntity> {
+
+  boolean existsByIdAndHabitUserId(UUID id, UUID userId);
+}

--- a/src/main/java/com/habittracker/api/checkin/service/CheckInService.java
+++ b/src/main/java/com/habittracker/api/checkin/service/CheckInService.java
@@ -17,4 +17,6 @@ public interface CheckInService {
 
   PagedModel<CheckInWithHabitResponse> getAllCheckIns(
       UserEntity user, Instant from, Instant to, Pageable pageable);
+
+  void deleteCheckIn(UUID checkInId, UserEntity user);
 }

--- a/src/main/java/com/habittracker/api/checkin/service/impl/CheckInServiceImpl.java
+++ b/src/main/java/com/habittracker/api/checkin/service/impl/CheckInServiceImpl.java
@@ -7,6 +7,7 @@ import com.habittracker.api.auth.model.UserEntity;
 import com.habittracker.api.checkin.CheckInResponse;
 import com.habittracker.api.checkin.dto.CheckInWithHabitResponse;
 import com.habittracker.api.checkin.exception.CheckInNotFoundException;
+import com.habittracker.api.checkin.helpers.CheckInHelper;
 import com.habittracker.api.checkin.mapper.CheckInMapper;
 import com.habittracker.api.checkin.model.CheckInEntity;
 import com.habittracker.api.checkin.repository.CheckInRepository;
@@ -33,6 +34,7 @@ public class CheckInServiceImpl implements CheckInService {
 
   private final CheckInRepository checkInRepository;
   private final HabitHelper habitHelper;
+  private final CheckInHelper checkInHelper;
   private final CheckInMapper checkInMapper;
   private final DailyCheckInService dailyCheckInService;
 
@@ -73,14 +75,11 @@ public class CheckInServiceImpl implements CheckInService {
   }
 
   @Override
+  @PreAuthorize("@checkInHelper.isOwnedByUser(#checkInId, principal.id)")
   @Transactional
   public void deleteCheckIn(UUID checkInId, UserEntity user) {
     CheckInEntity checkIn =
         checkInRepository.findById(checkInId).orElseThrow(CheckInNotFoundException::new);
-
-    if (!checkIn.getHabit().getUser().getId().equals(user.getId())) {
-      throw new CheckInNotFoundException();
-    }
 
     checkInRepository.delete(checkIn);
     log.debug("Deleted check-in with id {} for user {}", checkInId, user.getId());


### PR DESCRIPTION
## Summary
Implements DELETE endpoint for check-ins, allowing users to remove incorrect check-ins from their habits. The endpoint includes proper authorization to ensure users can only delete check-ins belonging to their own habits.

## Changes
- **Added** `CheckInNotFoundException` extending `ResourceNotFoundException` for consistent error handling
- **Added** `CHECK_IN_NOT_FOUND_MESSAGE` constant in `CheckInConstants`
- **Added** `deleteCheckIn(UUID checkInId, UserEntity user)` method to `CheckInService` interface
- **Implemented** `deleteCheckIn` method in `CheckInServiceImpl` with ownership validation through habit relationship
- **Added** `DELETE /api/check-ins/{checkInId}` endpoint in `CheckInController` returning 204 No Content on success

## Issue
Closes #69

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (Postman)
- [ ] All tests pass

## Checklist
- [x] Code builds successfully
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or documented)
- [ ] Code review requested