### PR TITLE
fix: refresh token cookie for cross-origin requests

### DIFF
--- a/src/main/java/com/habittracker/api/auth/utils/RefreshTokenCookieUtils.java
+++ b/src/main/java/com/habittracker/api/auth/utils/RefreshTokenCookieUtils.java
@@ -32,7 +32,8 @@ public class RefreshTokenCookieUtils {
     return ResponseCookie.from(COOKIE_NAME, refreshToken)
         .httpOnly(true)
         .path("/")
-        .sameSite("Strict")
+        .secure(true)
+        .sameSite("None")
         .maxAge(maxAge)
         .build();
   }


### PR DESCRIPTION
## Summary
- Set `SameSite=None` and `Secure=true` on the refresh token cookie
- Fixes the frontend not sending the refresh token cookie in cross-origin (deployed) environments

## Test plan
- [x] Deploy and verify the frontend can refresh access tokens via the `/auth/refresh` endpoint
- [x] Confirm the `Set-Cookie` header includes `SameSite=None; Secure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)